### PR TITLE
Lock CSV package dependency to working interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "dependencies": {
     "csv": "0.1.0"
   },
+  "scripts": {
+    "postinstall": "build.sh"
+  },
   "author": "Robert Kosara <rkosara@me.com> (http://eagereyes.org/)",
   "main": "ip2cc",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git://github.com/eagereyes/node-ip2cc.git"
   },
+  "dependencies": {
+    "csv": "0.1.0"
+  },
   "author": "Robert Kosara <rkosara@me.com> (http://eagereyes.org/)",
   "main": "ip2cc",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "csv": "0.1.0"
   },
   "scripts": {
-    "postinstall": "build.sh"
+    "postinstall": "./build.sh"
   },
   "author": "Robert Kosara <rkosara@me.com> (http://eagereyes.org/)",
   "main": "ip2cc",


### PR DESCRIPTION
The node-csv-parser interface has changed drastically over the last few years including the interface. So locking down to version 0.1.0 of the csv package brings in the last known working interface that this package expects. And this allows the build.sh and prepare-data.js scripts to run correctly (after npm install is run).
